### PR TITLE
feat(test): add vitest setup with unit tests and fix tax number valid…

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -445,6 +445,7 @@
             "enterInvoiceTitle": "Please enter invoice title",
             "taxNumberTooLong": "Tax identification number cannot exceed 18 digits",
             "taxNumberDigitsOnly": "Tax identification number can only contain digits",
+            "taxNumberFormatInvalid": "Tax identification number must be 18 alphanumeric characters (digits and uppercase letters)",
             "invoiceTitleEmpty": "Invoice title cannot be empty"
         },
         "submitSuccess": "Application submitted successfully",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -446,6 +446,7 @@
             "enterInvoiceTitle": "请输入发票抬头",
             "taxNumberTooLong": "纳税人识别号不能超过18位",
             "taxNumberDigitsOnly": "纳税人识别号只能包含数字",
+            "taxNumberFormatInvalid": "纳税人识别号须为18位数字和大写字母",
             "invoiceTitleEmpty": "发票抬头不能为空"
         },
         "submitSuccess": "提交申请成功",

--- a/src/views/Home/components/invoice-modal.vue
+++ b/src/views/Home/components/invoice-modal.vue
@@ -358,14 +358,9 @@ const formRules = computed(() => {
 
         rules.taxNumber = {
             validator: (rule: FormItemRule, value: string) => {
-                if (value && value.length > 18) {
+                if (value && !/^[0-9A-Z]{18}$/.test(value)) {
                     showTaxNumberFeedback.value = true;
-                    return new Error(t('invoiceModal.validation.taxNumberTooLong'));
-                }
-                // 验证如果填写了纳税人识别号，只能是数字
-                if (value && !/^\d+$/.test(value)) {
-                    showTaxNumberFeedback.value = true;
-                    return new Error(t('invoiceModal.validation.taxNumberDigitsOnly'));
+                    return new Error(t('invoiceModal.validation.taxNumberFormatInvalid'));
                 }
                 showTaxNumberFeedback.value = false;
 


### PR DESCRIPTION
…ation

- Add vitest configuration and test infrastructure (vitest.config.ts, happy-dom, @vue/test-utils)
- Add unit tests for annual summary, auth/user services, store, utils, and composables
- Fix tax number validation to accept 18 alphanumeric characters (digits and uppercase letters)
- Add taxNumberFormatInvalid locale messages in en/zh
- Switch dev proxy target from costrict to zgsm.sangfor.com
- Add AGENTS.md and design spec for annual-summary-fix