### PR TITLE
fix(credit): fix credit display precision and hide survey entry

### DIFF
--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -1,0 +1,44 @@
+/**
+ * @file number.ts
+ * @description 数字格式化与精度安全工具
+ */
+
+const CREDIT_DECIMALS = 2;
+const FLOAT_FIX_FACTOR = Math.pow(10, CREDIT_DECIMALS);
+
+/**
+ * 将数值四舍五入到 2 位小数，消除 0.1 + 0.2 = 0.30000000000000004 这类浮点误差。
+ */
+export function roundCredit(value: number): number {
+    if (!Number.isFinite(value)) return 0;
+    return Math.round(value * FLOAT_FIX_FACTOR) / FLOAT_FIX_FACTOR;
+}
+
+/**
+ * 安全减法，结果经过 roundCredit 处理，避免浮点精度误差外泄。
+ */
+export function safeSubtract(a: number, b: number): number {
+    if (!Number.isFinite(a) || !Number.isFinite(b)) return 0;
+    return roundCredit(a - b);
+}
+
+/**
+ * 格式化 Credit 数量用于展示：
+ * - 整数直接显示（如 3500）
+ * - 非整数保留 2 位小数（如 0.5、1.25）
+ * - 内部先做 roundCredit 防止浮点噪声
+ */
+export function formatCredit(value: number): string {
+    const rounded = roundCredit(value);
+    return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(CREDIT_DECIMALS);
+}
+
+/**
+ * 格式化 Credit 数量用于汇总展示，始终保留 2 位小数：
+ * - 适用于「已使用 / 总额 / 剩余」这类需要稳定对齐的财务化展示
+ * - 内部先做 roundCredit 防止浮点噪声
+ */
+export function formatCreditFixed(value: number): string {
+    const rounded = roundCredit(value);
+    return rounded.toFixed(CREDIT_DECIMALS);
+}

--- a/src/views/Home/components/subscription-section.vue
+++ b/src/views/Home/components/subscription-section.vue
@@ -25,7 +25,7 @@
             src="../../../assets/subscription/bg_5.png"
             alt=""
         />
-        <div class="subscription-survey">
+        <div v-if="false" class="subscription-survey">
             <div class="subscription-survey__copy flex items-center">
                 <img
                     src="../../../assets/subscription/gift.webp"

--- a/src/views/Home/components/usage-consumption-section.vue
+++ b/src/views/Home/components/usage-consumption-section.vue
@@ -38,6 +38,7 @@ import { useI18n } from 'vue-i18n';
 import { NDataTable, NPagination } from 'naive-ui';
 import type { UsageConsumptionRecord } from '@/api/bos/quota.bo';
 import { formatDate } from '@/utils/date';
+import { formatCredit } from '@/utils/number';
 import { withDefaultRender } from '../hook/useTableRender';
 
 const { t } = useI18n();
@@ -95,6 +96,7 @@ const columns = computed(() =>
             title: t('homePage.creditsUsed'),
             key: 'credits_used',
             width: 120,
+            render: (row: UsageConsumptionRecord) => formatCredit(row.credits_used),
         },
         {
             title: t('homePage.package'),

--- a/src/views/Home/components/usage-section.vue
+++ b/src/views/Home/components/usage-section.vue
@@ -75,6 +75,7 @@ import { useI18n } from 'vue-i18n';
 import { NProgress, NCollapse, NCollapseItem, NDataTable } from 'naive-ui';
 import type { QuotaList } from '@/api/bos/quota.bo';
 import { formatDate } from '@/utils/date';
+import { formatCredit, formatCreditFixed, safeSubtract } from '@/utils/number';
 import { withDefaultRender } from '../hook/useTableRender';
 
 const { t } = useI18n();
@@ -108,7 +109,7 @@ const percentage = computed(() => {
 });
 
 const remainingQuota = computed(() => {
-    return props.totalQuota - props.usedQuota;
+    return safeSubtract(props.totalQuota, props.usedQuota);
 });
 
 const withDefaultColumnRender = withDefaultRender<QuotaList>();
@@ -124,6 +125,8 @@ const columns = computed(() =>
         {
             title: t('homePage.creditNum'),
             key: 'amount',
+            width: 120,
+            render: (row: QuotaList) => formatCredit(row.amount),
         },
         {
             title: t('homePage.source'),
@@ -133,9 +136,7 @@ const columns = computed(() =>
 );
 
 // 方法
-const formatNumber = (num: number): string => {
-    return num.toFixed(2);
-};
+const formatNumber = (num: number): string => formatCreditFixed(num);
 </script>
 
 <style scoped lang="less">


### PR DESCRIPTION
- Add number utils (roundCredit / safeSubtract / formatCredit / formatCreditFixed) to eliminate floating-point noise and provide consistent formatting
- usage-section: summary stats use formatCreditFixed (always 2 decimals), quota table column uses formatCredit (smart integer/decimal display), remaining quota computed via safeSubtract to avoid float artifacts
- usage-consumption-section: credits_used column uses formatCredit
- subscription-section: hide survey entry with v-if="false"