### PR TITLE
fix(auth): isolate oidc-auth token from cross-domain cs-user cookie

### DIFF
--- a/src/__tests__/utils.token.spec.ts
+++ b/src/__tests__/utils.token.spec.ts
@@ -67,7 +67,7 @@ describe('token utils', () => {
 
             const result = getToken();
 
-            expect(Cookies.get).toHaveBeenCalledWith('zgsmAdminToken');
+            expect(Cookies.get).toHaveBeenCalledWith('oidcAdminToken');
             expect(result).toBe(mockToken);
         });
 
@@ -86,14 +86,15 @@ describe('token utils', () => {
 
             setToken(token);
 
-            expect(Cookies.set).toHaveBeenCalledWith('zgsmAdminToken', token);
+            expect(Cookies.set).toHaveBeenCalledWith('oidcAdminToken', token);
         });
     });
 
     describe('clearToken', () => {
-        it('should remove token from cookies', () => {
+        it('should remove token from cookies and clear legacy cookie', () => {
             clearToken();
 
+            expect(Cookies.remove).toHaveBeenCalledWith('oidcAdminToken');
             expect(Cookies.remove).toHaveBeenCalledWith('zgsmAdminToken');
         });
     });

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -1,6 +1,9 @@
 import Cookies from 'js-cookie';
 
-const TOKEN_KEY = 'zgsmAdminToken';
+const TOKEN_KEY = 'oidcAdminToken';
+// Legacy cookie shared via parent domain (*.sangfor.com) — may carry cs-user tokens
+// that oidc-auth cannot validate. Cleared on logout to avoid stale cross-domain token.
+const LEGACY_TOKEN_KEY = 'zgsmAdminToken';
 
 export const getHashToken = () => {
     const url = new URL(window.location.href);
@@ -19,6 +22,7 @@ export const setToken = (token: string) => {
 };
 
 export const clearToken = () => {
+    Cookies.remove(LEGACY_TOKEN_KEY);
     return Cookies.remove(TOKEN_KEY);
 };
 


### PR DESCRIPTION
Rename the admin token cookie from zgsmAdminToken (shared via parent domain *.sangfor.com with cs-user tokens) to oidcAdminToken, so this UI only reads oidc-auth-issued tokens. clearToken also wipes the legacy zgsmAdminToken cookie to prevent stale cross-domain tokens lingering after logout.

Root cause: cs-user tokens entered the cookie via parent-domain sharing, then were sent to oidc-auth endpoints, where GetUserByTokenHash (DB hash lookup) rejects them with "invalid token, no related account exists".